### PR TITLE
Fix image not displaying issue

### DIFF
--- a/src/components/AddNewVisitModal.vue
+++ b/src/components/AddNewVisitModal.vue
@@ -290,9 +290,9 @@ export default defineComponent({
       //     ? this.formatDateForInput(admin.lastMenstrualPeriod)
       //     : null
       this.drugAllergies = admin.drugAllergies
-      this.photo = admin.photo
+      this.photo = admin.photo ? atob(admin.photo) : null
       // this.sentToId = admin.sentToId
-      this.selectedPhoto = this.photo ? `data:image/png;base64,${atob(this.photo)}` : ''
+      this.selectedPhoto = this.photo ? `data:image/png;base64,${this.photo}` : ''
     }
   },
   emits: ['patientVisitCreated'],

--- a/src/components/AdminModal.vue
+++ b/src/components/AdminModal.vue
@@ -307,10 +307,10 @@ export default defineComponent({
             ? this.formatDateForInput(admin.lastMenstrualPeriod)
             : null
         this.drugAllergies = admin.drugAllergies
-        this.photo = admin.photo
+        this.photo = admin.photo ? atob(admin.photo) : null // Decode base64 string
         this.sentToId = admin.sentToId
 
-        this.selectedPhoto = this.photo ? `data:image/png;base64,${atob(this.photo)}` : ''
+        this.selectedPhoto = this.photo ? `data:image/png;base64,${this.photo}` : ''
       }
     },
     gender(newValue) {
@@ -425,7 +425,7 @@ export default defineComponent({
             : null,
           drugAllergies: this.drugAllergies || null,
           sentToId: this.sentToId,
-          photo: this.photo || null
+          photo: this.photo || null // sending over as decoded base64 string, encoded in the backend
         }
 
         if (this.isAdd && !this.isEditing) {


### PR DESCRIPTION
Previously, when one goes into any patient with image, clicks edit and then clicks save without editing, when you click out of the patient and click back in, the image cannot be displayed. But this does not happen when a user clicks edit, uploads a photo and then clicks save. 

The reason why this was happening was because when there is no image upload, the photo which was being sent over to the backend for storage was the encoded version. However, the encoding is done in the backend, hence it should be sent over as a decoded string.
Hence it has been changed to ensure that the decoded string is sent over, so that there is no double encoding in both the backend and frontend which results in issues displaying the image. 